### PR TITLE
add support to use a more natural language with a dirty regexp

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -12,7 +12,7 @@ import pyowm #informacion meteorologica
 import login #informacion personal para log in del bot
 
 
-PATTERN = re.compile(r'!(talloviendo) ?(\"[a-z ]*\")?')
+PATTERN = re.compile(r'!(talloviendo) ?(?:(?:\")?(?:en )?)([a-z ]*)(?:\")?')
 
 def update_log(id, log_path): #para los comentarios que ya respondi
     with open(log_path, 'a') as my_log:
@@ -34,13 +34,13 @@ def output_log(text, debug_mode=False): #lo uso para ver el output del bot
     if debug_mode: print(text)
 
 def check_condition(c): #llamaron al bot?
-    aux = PATTERN.search(c.body.lower()) 
+    aux = PATTERN.search(c.body.lower())
     if aux == None:
         return False
-    elif not aux.group(2) or len(aux.group(2))<3:
+    elif not aux.group(2) or len(aux.group(2)) < 2:
         return 'Montevideo'
     else:
-        return aux.group(2)[1:-1]
+        return aux.group(2)
 
 def get_temperature(w):
     temp_dict = w.get_temperature(unit='celsius')


### PR DESCRIPTION
Agrega soporte para que no haya que poner el lugar entre comillas como un bot.

usando (demasiados) grupos de no-captura expande el lenguaje aceptado a:

!talloViendo
!talloViendo "Rocha"
!talloViendo en Rocha
!talloViendo en Treinta y Tres

aprovechando los grupos de no-captura no hay que cortar mas las comillas de la respuesta, la regexp se encarga de solo retornar el texto necesario.

edit: acá esta el "test case" que arme para ver como anda la regexp https://regex101.com/r/A9EYmi/1