### PR TITLE
Escapar un !talloViendo

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -13,8 +13,8 @@ import login #informacion personal para log in del bot
 
 
 PATTERN = re.compile(
-    r'!talloviendo ?(?:en )?(\"?)([a-záéíóúñ ]+?\b)?\1',
-    re.IGNORECASE) #Tests: https://regex101.com/r/dovCdU/3
+    r'(?<!\\)!talloviendo ?(?:en )?(\"?)([a-záéíóúñ ]+?\b)?\1', 
+    re.IGNORECASE) #Tests: https://regex101.com/r/dovCdU/4
 
 def update_log(id, log_path): #para los comentarios que ya respondi
     with open(log_path, 'a') as my_log:


### PR DESCRIPTION
La idea es poder decir `\!talloViendo` para que el bot no salte. En Reddit esa barra no se vé.  
[De acá surgió la idea](https://www.reddit.com/r/uruguay/comments/8amc3g/talloviendo_ahora_te_permite_elegir_el_lugar/dwzx777/).

Pensé usar:

    (?:^|[^\\])!talloviendo ?(?:en )?(\"?)([a-záéíóúñ ]+?\b)?\1

Pero resulta que:

    (?<!\\)!talloviendo ?(?:en )?(\"?)([a-záéíóúñ ]+?\b)?\1

Es más rápido, claro y no incluye el caracter anterior (si existe) en el grupo 0.